### PR TITLE
Polyfill for getSnapshotBeforeUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ Currently, this polyfill supports [static `getDerivedStateFromProps`](https://de
 
 Note that in order for the polyfill to work, none of the following lifecycles can be defined by your component: `componentWillMount`, `componentWillReceiveProps`, or `componentWillUpdate`.
 
-Note also that if your component contains `getSnapshotBeforeUpdate`, `componentWillUpdate` must be defined as well.
+Note also that if your component contains `getSnapshotBeforeUpdate`, `componentDidUpdate` must be defined as well.
 
 An error will be thrown if any of the above conditions are not met.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 React version 17 will deprecate several of the class component API lifecycles: `componentWillMount`, `componentWillReceiveProps`, and `componentWillUpdate`. (Read the [Update on Async rendering blog post](https://deploy-preview-596--reactjs.netlify.com/blog/2018/03/15/update-on-async-rendering.html) to learn more about why.) A couple of new lifecycles are also being added to better support [async rendering mode](https://reactjs.org/blog/2018/03/01/sneak-peek-beyond-react-16.html).
 
-Typically, this type of change would require third party libraries to release a new major version in order to adhere to semver. However, the `react-lifecycles-compat` polyfill offers a way to use the new lifecycles with older versions of React as well (0.14.9+) so no breaking release is required!
+Typically, this type of change would require third party libraries to release a new major version in order to adhere to semver. However, the `react-lifecycles-compat` polyfill offers a way to use the new lifecycles with older versions of React as well (0.14.9+) so no breaking release is required. This enables shared libraries to support both older and newer versions of React simultaneously.
 
 ## How can I use the polyfill
 
@@ -37,3 +37,11 @@ export default ExampleComponent;
 ## Which lifecycles are supported?
 
 Currently, this polyfill supports [static `getDerivedStateFromProps`](https://deploy-preview-587--reactjs.netlify.com/docs/react-component.html#static-getderivedstatefromprops) and [`getSnapshotBeforeUpdate`](https://deploy-preview-587--reactjs.netlify.com/docs/react-component.html#getsnapshotbeforeupdate)- both introduced in version 16.3.
+
+## Validation
+
+Note that in order for the polyfill to work, none of the following lifecycles can be defined by your component: `componentWillMount`, `componentWillReceiveProps`, or `componentWillUpdate`.
+
+Note also that if your component contains `getSnapshotBeforeUpdate`, `componentWillUpdate` must be defined as well.
+
+An error will be thrown if any of the above conditions are not met.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## What is this project?
 
-React version 17 will deprecate several of the class component API lifecycles: `componentWillMount`, `componentWillReceiveProps`, and `componentWillUpdate` and introduce a couple of new ones. (Check out the [ReactJS blog](https://reactjs.org/blog) for more information about this decision.)
+React version 17 will deprecate several of the class component API lifecycles: `componentWillMount`, `componentWillReceiveProps`, and `componentWillUpdate`. (Read the [Update on Async rendering blog post](https://deploy-preview-596--reactjs.netlify.com/blog/2018/03/15/update-on-async-rendering.html) to learn more about why.) A couple of new lifecycles are also being added to better support [async rendering mode](https://reactjs.org/blog/2018/03/01/sneak-peek-beyond-react-16.html).
 
-This would typically require any third party libraries dependent on those lifecycles to release a new major version in order to adhere to semver. However, the `react-lifecycles-compat` polyfill offers a way to remain compatible with older versions of React (0.14.9+). 🎉😎
+Typically, this type of change would require third party libraries to release a new major version in order to adhere to semver. However, the `react-lifecycles-compat` polyfill offers a way to use the new lifecycles with older versions of React as well (0.14.9+) so no breaking release is required!
 
 ## How can I use the polyfill
 
@@ -17,9 +17,9 @@ yarn add react-lifecycles-compat
 npm install react-lifecycles-compat --save
 ```
 
-Next, update your component and replace any of the deprecated lifecycles with new ones introduced with React 16.3. (See [the examples](#examples) below.)
+Next, update your component and replace any of the deprecated lifecycles with new ones introduced with React 16.3. (Refer to the React docs for [examples of how to use the new lifecycles](https://deploy-preview-596--reactjs.netlify.com/blog/2018/03/15/update-on-async-rendering.html).)
 
-Lastly, use the polyfill to make your component backwards compatible with older versions of React:
+Lastly, use the polyfill to make the new lifecycles work with older versions of React:
 ```js
 import React from 'react';
 import polyfill from 'react-lifecycles-compat';
@@ -34,106 +34,6 @@ polyfill(ExampleComponent);
 export default ExampleComponent;
 ```
 
-## Examples
+## Which lifecycles are supported?
 
-### `getDerivedStateFromProps` example
-Before:
-```js
-class ExampleComponent extends React.Component {
-  state = {
-    isScrollingDown: false,
-  };
-
-  componentWillReceiveProps(nextProps) {
-    if (this.props.currentRow !== nextProps.currentRow) {
-      this.setState({
-        isScrollingDown:
-          nextProps.currentRow > this.props.currentRow,
-      });
-    }
-  }
-}
-```
-After:
-```js
-class ExampleComponent extends React.Component {
-  // Initialize state in constructor,
-  // Or with a property initializer.
-  state = {
-    isScrollingDown: false,
-    lastRow: null,
-  };
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (nextProps.currentRow !== prevState.lastRow) {
-      return {
-        isScrollingDown:
-          nextProps.currentRow > prevState.lastRow,
-        lastRow: nextProps.currentRow,
-      };
-    }
-
-    // Return null to indicate no change to state.
-    return null;
-  }
-}
-```
-
-### `getSnapshotBeforeUpdate` example
-
-Before:
-```js
-class ScrollingList extends React.Component {
-  listRef = null;
-  prevScrollHeight = null;
-
-  componentWillUpdate(nextProps, nextState) {
-    if (this.props.list.length < nextProps.list.length) {
-      this.prevScrollHeight = this.listRef.scrollHeight;
-    }
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (this.prevScrollHeight !== null) {
-      this.listRef.scrollTop +=
-        this.listRef.scrollHeight - this.prevScrollHeight;
-      this.prevScrollHeight = null;
-    }
-  }
-
-  render() {
-    return <div ref={this.setListRef}>{/* ...contents... */}</div>;
-  }
-
-  setListRef = ref => {
-    this.listRef = ref;
-  };
-}
-```
-After:
-```js
-class ScrollingList extends React.Component {
-  listRef = null;
-
-  getSnapshotBeforeUpdate(prevProps, prevState) {
-    if (prevProps.list.length < this.props.list.length) {
-      return this.listRef.scrollHeight;
-    }
-    return null;
-  }
-
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    if (snapshot !== null) {
-      this.listRef.scrollTop += this.listRef.scrollHeight - snapshot;
-    }
-  }
-
-  render() {
-    return <div ref={this.setListRef}>{/* ...contents... */}</div>;
-  }
-
-  setListRef = ref => {
-    this.listRef = ref;
-  };
-}
-```
+Currently, this polyfill supports [static `getDerivedStateFromProps`](https://deploy-preview-587--reactjs.netlify.com/docs/react-component.html#static-getderivedstatefromprops) and [`getSnapshotBeforeUpdate`](https://deploy-preview-587--reactjs.netlify.com/docs/react-component.html#getsnapshotbeforeupdate)- both introduced in version 16.3.

--- a/index.js
+++ b/index.js
@@ -31,12 +31,15 @@ function componentWillUpdate(nextProps, nextState) {
   var prevState = this.state;
   this.props = nextProps;
   this.state = nextState;
-  this.__reactInternalSnapshot = this.getSnapshotBeforeUpdate(
-    prevProps,
-    prevState
-  );
-  this.props = prevProps;
-  this.state = prevState;
+  try {
+    this.__reactInternalSnapshot = this.getSnapshotBeforeUpdate(
+      prevProps,
+      prevState
+    );
+  } finally {
+    this.props = prevProps;
+    this.state = prevState;
+  }
 }
 
 // React may warn about cWM/cWRP/cWU methods being deprecated.

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = function polyfill(Component) {
     }
     if (typeof Component.prototype.componentDidUpdate !== 'function') {
       throw new Error(
-        'Cannot polyfill getSnapshotBeforeUpdate() for components that do not define componentDidUpdate()'
+        'Cannot polyfill getSnapshotBeforeUpdate() for components that do not define componentDidUpdate() on the prototype'
       );
     }
 

--- a/index.js
+++ b/index.js
@@ -27,11 +27,11 @@ function componentWillReceiveProps(nextProps) {
 }
 
 function componentWillUpdate(nextProps, nextState) {
-  var prevProps = this.props;
-  var prevState = this.state;
-  this.props = nextProps;
-  this.state = nextState;
   try {
+    var prevProps = this.props;
+    var prevState = this.state;
+    this.props = nextProps;
+    this.state = nextState;
     this.__reactInternalSnapshot = this.getSnapshotBeforeUpdate(
       prevProps,
       prevState
@@ -55,12 +55,14 @@ module.exports = function polyfill(Component) {
 
   if (typeof Component.getDerivedStateFromProps === 'function') {
     if (typeof Component.prototype.componentWillMount === 'function') {
-      throw new Error('Cannot polyfill if componentWillMount already exists');
+      throw new Error(
+        'Cannot polyfill getDerivedStateFromProps() for components that define componentWillMount()'
+      );
     } else if (
       typeof Component.prototype.componentWillReceiveProps === 'function'
     ) {
       throw new Error(
-        'Cannot polyfill if componentWillReceiveProps already exists'
+        'Cannot polyfill getDerivedStateFromProps() for components that define componentWillReceiveProps()'
       );
     }
 
@@ -70,12 +72,13 @@ module.exports = function polyfill(Component) {
 
   if (typeof Component.prototype.getSnapshotBeforeUpdate === 'function') {
     if (typeof Component.prototype.componentWillUpdate === 'function') {
-      throw new Error('Cannot polyfill if componentWillUpdate already exists');
+      throw new Error(
+        'Cannot polyfill getSnapshotBeforeUpdate() for components that define componentWillUpdate()'
+      );
     }
-
     if (typeof Component.prototype.componentDidUpdate !== 'function') {
       throw new Error(
-        'Cannot polyfill getSnapshotBeforeUpdate() unless componentDidUpdate() exists on the prototype'
+        'Cannot polyfill getSnapshotBeforeUpdate() for components that do not define componentDidUpdate()'
       );
     }
 

--- a/test.js
+++ b/test.js
@@ -337,7 +337,7 @@ Object.entries(POLYFILLS).forEach(([name, polyfill]) => {
           }
 
           expect(() => polyfill(Component)).toThrow(
-            'Cannot polyfill getSnapshotBeforeUpdate() for components that do not define componentDidUpdate()'
+            'Cannot polyfill getSnapshotBeforeUpdate() for components that do not define componentDidUpdate() on the prototype'
           );
         });
       });

--- a/test.js
+++ b/test.js
@@ -119,6 +119,9 @@ Object.entries(POLYFILLS).forEach(([name, polyfill]) => {
             constructor(props) {
               super(props);
               this.state = {count: 1};
+              this.setRef = ref => {
+                this.divRef = ref;
+              };
             }
             static getDerivedStateFromProps(nextProps, prevState) {
               return {
@@ -126,18 +129,26 @@ Object.entries(POLYFILLS).forEach(([name, polyfill]) => {
               };
             }
             getSnapshotBeforeUpdate(prevProps, prevState) {
-              return prevState.count * 2 + this.state.count * 3;
+              expect(prevProps).toEqual({incrementBy: 2});
+              expect(prevState).toEqual({count: 3});
+              return this.divRef.textContent;
             }
             componentDidUpdate(prevProps, prevState, snapshot) {
               expect(prevProps).toEqual({incrementBy: 2});
               expect(prevState).toEqual({count: 3});
               expect(this.props).toEqual({incrementBy: 3});
               expect(this.state).toEqual({count: 6});
-              expect(snapshot).toBe(24);
+              expect(snapshot).toBe('3');
               componentDidUpdateCalled = true;
             }
             render() {
-              return React.createElement('div', null, this.state.count);
+              return React.createElement(
+                'div',
+                {
+                  ref: this.setRef,
+                },
+                this.state.count
+              );
             }
           }
 


### PR DESCRIPTION
Potential polyfill for `getSnapshotBeforeUpdate` (RFC: reactjs/rfcs/pull/33, implementation: facebook/react/pull/12404).

~~Note that if we did use this approach, we'd need to update React to also look for a `__suppressDeprecationWarning` flag on the `componentWillUpdate` method before logging a DEV warning.~~ (Added to facebook/react/pull/12404)

I'm currently on the fence about whether we should polyfill `getSnapshotBeforeUpdate` using this technique. It would be useful for libs that rely on it, so they could avoid having to break backwards compatibility with supported React versions.