### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Backwards compatibility polyfill for React class components",
   "main": "index.js",
   "license": "MIT",
+  "repository": "reactjs/react-lifecycles-compat",
   "scripts": {
     "test": "jest test.js",
     "build:dev": "NODE_ENV=development webpack",


### PR DESCRIPTION
Currently `npm repo react-lifecycles-compat` errors and the [npm package page](https://www.npmjs.com/package/react-lifecycles-compat) doesn't point at the repo, which makes it hard to track down the source for the package.

This PR will fix both next time the package is published.