### PR TITLE
Use named "polyfill" export and support ES module target

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Next, update your component and replace any of the deprecated lifecycles with ne
 Lastly, use the polyfill to make the new lifecycles work with older versions of React:
 ```js
 import React from 'react';
-import polyfill from 'react-lifecycles-compat';
+import {polyfill} from 'react-lifecycles-compat';
 
 class ExampleComponent extends React.Component {
   // ...

--- a/index.js
+++ b/index.js
@@ -91,6 +91,8 @@ export default function polyfill(Component) {
     ) {
       // 16.3+ will pass a snapshot value.
       // Older versions will rely on our polyfilled value.
+      // It's important to check for the "__reactInternalSnapshot" value first though,
+      // Since <= 15.x versions of React will pass a prevContext param to componentDidUpdate.
       var snapshot = this.__reactInternalSnapshot || maybeSnapshot;
 
       componentDidUpdate.call(this, prevProps, prevState, snapshot);

--- a/index.js
+++ b/index.js
@@ -90,11 +90,13 @@ export function polyfill(Component) {
       prevState,
       maybeSnapshot
     ) {
-      // 16.3+ will not execute our will-update method, but will still pass a snapshot value to did-update.
-      // Older versions will rely on our polyfilled will-update behavior.
-      // We can't just check for the presence of "maybeSnapshot",
+      // 16.3+ will not execute our will-update method;
+      // It will pass a snapshot value to did-update though.
+      // Older versions will require our polyfilled will-update value.
+      // We need to handle both cases, but can't just check for the presence of "maybeSnapshot",
       // Because for <= 15.x versions this might be a "prevContext" object.
-      // We should also guard against falsy snapshot return values,
+      // We also can't just check "__reactInternalSnapshot",
+      // Because get-snapshot might return a falsy value.
       // So check for the explicit __reactInternalSnapshotFlag flag to determine behavior.
       var snapshot = this.__reactInternalSnapshotFlag
         ? this.__reactInternalSnapshot

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ componentWillMount.__suppressDeprecationWarning = true;
 componentWillReceiveProps.__suppressDeprecationWarning = true;
 componentWillUpdate.__suppressDeprecationWarning = true;
 
-export default function polyfill(Component) {
+export function polyfill(Component) {
   if (!Component.prototype || !Component.prototype.isReactComponent) {
     throw new Error('Can only polyfill class components');
   }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "react-lifecycles-compat",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Backwards compatibility polyfill for React class components",
   "main": "react-lifecycles-compat.cjs.js",
+  "module": "react-lifecycles-compat.es.js",
   "license": "MIT",
   "repository": "reactjs/react-lifecycles-compat",
   "scripts": {
@@ -16,6 +17,7 @@
   },
   "files": [
     "react-lifecycles-compat.cjs.js",
+    "react-lifecycles-compat.es.js",
     "react-lifecycles-compat.js",
     "react-lifecycles-compat.min.js"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ export default [
   createConfig({
     output: [
       { file: pkg.main, format: 'cjs' },
-      // Re-enable for 2.0 { file: pkg.module, format: 'es' },
+      { file: pkg.module, format: 'es' },
     ],
   }),
   createConfig({

--- a/test.js
+++ b/test.js
@@ -9,17 +9,19 @@ const POLYFILLS = {
   'umd: prod': require('./react-lifecycles-compat.min'),
 };
 
-Object.entries(POLYFILLS).forEach(([name, polyfill]) => {
+Object.entries(POLYFILLS).forEach(([name, module]) => {
   describe(`react-lifecycles-compat (${name})`, () => {
     readdirSync(join(__dirname, 'react')).forEach(version => {
       const basePath = `./react/${version}/node_modules/`;
 
       let createReactClass;
+      let polyfill;
       let React;
       let ReactDOM;
 
       beforeEach(() => {
         createReactClass = require(basePath + 'create-react-class');
+        polyfill = module.polyfill;
         React = require(basePath + 'react');
         ReactDOM = require(basePath + 'react-dom');
       });

--- a/test.js
+++ b/test.js
@@ -19,7 +19,7 @@ Object.entries(POLYFILLS).forEach(([name, module]) => {
       let React;
       let ReactDOM;
 
-      beforeEach(() => {
+      beforeAll(() => {
         createReactClass = require(basePath + 'create-react-class');
         polyfill = module.polyfill;
         React = require(basePath + 'react');

--- a/test.js
+++ b/test.js
@@ -293,6 +293,56 @@ Object.entries(POLYFILLS).forEach(([name, module]) => {
           }
         });
 
+        it('should properly handle falsy return values from getSnapshotBeforeUpdate()', () => {
+          let componentDidUpdateCalls = 0;
+
+          class Component extends React.Component {
+            getSnapshotBeforeUpdate(prevProps) {
+              return prevProps.value;
+            }
+            componentDidUpdate(prevProps, prevState, snapshot) {
+              expect(snapshot).toBe(prevProps.value);
+              componentDidUpdateCalls++;
+            }
+            render() {
+              return null;
+            }
+          }
+
+          polyfill(Component);
+
+          const container = document.createElement('div');
+          ReactDOM.render(
+            React.createElement(Component, {value: 'initial'}),
+            container
+          );
+          expect(componentDidUpdateCalls).toBe(0);
+
+          ReactDOM.render(
+            React.createElement(Component, {value: null}),
+            container
+          );
+          expect(componentDidUpdateCalls).toBe(1);
+
+          ReactDOM.render(
+            React.createElement(Component, {value: false}),
+            container
+          );
+          expect(componentDidUpdateCalls).toBe(2);
+
+          ReactDOM.render(
+            React.createElement(Component, {value: undefined}),
+            container
+          );
+          expect(componentDidUpdateCalls).toBe(3);
+
+          ReactDOM.render(
+            React.createElement(Component, {value: 123}),
+            container
+          );
+          expect(componentDidUpdateCalls).toBe(4);
+        });
+
         it('should error for non-class components', () => {
           function FunctionalComponent() {
             return null;


### PR DESCRIPTION
In order to support ES modules in version 2.0, this PR replaces the default export with a named "polyfill" export (and re-enabled ES module target).

Related docs update PR: reactjs/reactjs.org/pull/764

Resolves #8