### PR TITLE
Add addition DEV warnings for mixed old and new API lifecycles

### DIFF
--- a/test.js
+++ b/test.js
@@ -27,12 +27,12 @@ Object.entries(POLYFILLS).forEach(([name, module]) => {
       });
 
       describe(`react@${version}`, () => {
-        beforeAll(() => {
+        beforeEach(() => {
           jest.spyOn(console, 'error');
           global.console.error.mockImplementation(() => {});
         });
 
-        afterAll(() => {
+        afterEach(() => {
           global.console.error.mockRestore();
         });
 
@@ -416,6 +416,203 @@ Object.entries(POLYFILLS).forEach(([name, module]) => {
             'Cannot polyfill getSnapshotBeforeUpdate() for components that do not define componentDidUpdate() on the prototype'
           );
         });
+
+        if (name === 'cjs') {
+          it('should warn if a component tries to combine gDSFP with cWU or any of the UNSAFE_ lifecycles', () => {
+            class ComponentWithWillUpdate extends React.Component {
+              componentWillUpdate() {}
+              static getDerivedStateFromProps() {}
+              render() {
+                return null;
+              }
+            }
+
+            expect(console.error.mock.calls).toHaveLength(0);
+            polyfill(ComponentWithWillUpdate);
+            expect(console.error.mock.calls).toHaveLength(1);
+            expect(console.error.mock.calls[0][0]).toEqual(
+              'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
+                'ComponentWithWillUpdate uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+                '  componentWillUpdate\n\n' +
+                'The above lifecycles should be removed. Learn more about this warning here:\n' +
+                'https://fb.me/react-async-component-lifecycle-hooks'
+            );
+
+            console.error.mockClear();
+
+            class ComponentWithUnsafeWillMount extends React.Component {
+              UNSAFE_componentWillMount() {}
+              static getDerivedStateFromProps() {}
+              render() {
+                return null;
+              }
+            }
+
+            expect(console.error.mock.calls).toHaveLength(0);
+            polyfill(ComponentWithUnsafeWillMount);
+            expect(console.error.mock.calls).toHaveLength(1);
+            expect(console.error.mock.calls[0][0]).toEqual(
+              'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
+                'ComponentWithUnsafeWillMount uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+                '  UNSAFE_componentWillMount\n\n' +
+                'The above lifecycles should be removed. Learn more about this warning here:\n' +
+                'https://fb.me/react-async-component-lifecycle-hooks'
+            );
+
+            console.error.mockClear();
+
+            class ComponentWithUnsafeWillReceiveProps extends React.Component {
+              UNSAFE_componentWillReceiveProps() {}
+              static getDerivedStateFromProps() {}
+              render() {
+                return null;
+              }
+            }
+
+            expect(console.error.mock.calls).toHaveLength(0);
+            polyfill(ComponentWithUnsafeWillReceiveProps);
+            expect(console.error.mock.calls).toHaveLength(1);
+            expect(console.error.mock.calls[0][0]).toEqual(
+              'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
+                'ComponentWithUnsafeWillReceiveProps uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+                '  UNSAFE_componentWillReceiveProps\n\n' +
+                'The above lifecycles should be removed. Learn more about this warning here:\n' +
+                'https://fb.me/react-async-component-lifecycle-hooks'
+            );
+
+            console.error.mockClear();
+
+            class ComponentWithUnsafeWillUpdate extends React.Component {
+              UNSAFE_componentWillUpdate() {}
+              static getDerivedStateFromProps() {}
+              render() {
+                return null;
+              }
+            }
+
+            expect(console.error.mock.calls).toHaveLength(0);
+            polyfill(ComponentWithUnsafeWillUpdate);
+            expect(console.error.mock.calls).toHaveLength(1);
+            expect(console.error.mock.calls[0][0]).toEqual(
+              'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
+                'ComponentWithUnsafeWillUpdate uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
+                '  UNSAFE_componentWillUpdate\n\n' +
+                'The above lifecycles should be removed. Learn more about this warning here:\n' +
+                'https://fb.me/react-async-component-lifecycle-hooks'
+            );
+          });
+
+          it('should warn if component tries to combine gSBU with cWM, cWRP, or any of the UNSAFE_ lifecycles', () => {
+            class ComponentWithWillMount extends React.Component {
+              componentWillMount() {}
+              componentDidUpdate() {}
+              getSnapshotBeforeUpdate() {}
+              render() {
+                return null;
+              }
+            }
+
+            expect(console.error.mock.calls).toHaveLength(0);
+            polyfill(ComponentWithWillMount);
+            expect(console.error.mock.calls).toHaveLength(1);
+            expect(console.error.mock.calls[0][0]).toEqual(
+              'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
+                'ComponentWithWillMount uses getSnapshotBeforeUpdate() but also contains the following legacy lifecycles:\n' +
+                '  componentWillMount\n\n' +
+                'The above lifecycles should be removed. Learn more about this warning here:\n' +
+                'https://fb.me/react-async-component-lifecycle-hooks'
+            );
+
+            console.error.mockClear();
+
+            class ComponentWithWillReceiveProps extends React.Component {
+              componentWillReceiveProps() {}
+              componentDidUpdate() {}
+              getSnapshotBeforeUpdate() {}
+              render() {
+                return null;
+              }
+            }
+
+            expect(console.error.mock.calls).toHaveLength(0);
+            polyfill(ComponentWithWillReceiveProps);
+            expect(console.error.mock.calls).toHaveLength(1);
+            expect(console.error.mock.calls[0][0]).toEqual(
+              'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
+                'ComponentWithWillReceiveProps uses getSnapshotBeforeUpdate() but also contains the following legacy lifecycles:\n' +
+                '  componentWillReceiveProps\n\n' +
+                'The above lifecycles should be removed. Learn more about this warning here:\n' +
+                'https://fb.me/react-async-component-lifecycle-hooks'
+            );
+
+            console.error.mockClear();
+            class ComponentWithUnsafeWillMount extends React.Component {
+              UNSAFE_componentWillMount() {}
+              componentDidUpdate() {}
+              getSnapshotBeforeUpdate() {}
+              render() {
+                return null;
+              }
+            }
+
+            expect(console.error.mock.calls).toHaveLength(0);
+            polyfill(ComponentWithUnsafeWillMount);
+            expect(console.error.mock.calls).toHaveLength(1);
+            expect(console.error.mock.calls[0][0]).toEqual(
+              'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
+                'ComponentWithUnsafeWillMount uses getSnapshotBeforeUpdate() but also contains the following legacy lifecycles:\n' +
+                '  UNSAFE_componentWillMount\n\n' +
+                'The above lifecycles should be removed. Learn more about this warning here:\n' +
+                'https://fb.me/react-async-component-lifecycle-hooks'
+            );
+
+            console.error.mockClear();
+
+            class ComponentWithUnsafeWillReceiveProps extends React.Component {
+              UNSAFE_componentWillReceiveProps() {}
+              componentDidUpdate() {}
+              getSnapshotBeforeUpdate() {}
+              render() {
+                return null;
+              }
+            }
+
+            expect(console.error.mock.calls).toHaveLength(0);
+            polyfill(ComponentWithUnsafeWillReceiveProps);
+            expect(console.error.mock.calls).toHaveLength(1);
+            expect(console.error.mock.calls[0][0]).toEqual(
+              'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
+                'ComponentWithUnsafeWillReceiveProps uses getSnapshotBeforeUpdate() but also contains the following legacy lifecycles:\n' +
+                '  UNSAFE_componentWillReceiveProps\n\n' +
+                'The above lifecycles should be removed. Learn more about this warning here:\n' +
+                'https://fb.me/react-async-component-lifecycle-hooks'
+            );
+
+            console.error.mockClear();
+
+            class ComponentWithUnsafeWillUpdate extends React.Component {
+              UNSAFE_componentWillUpdate() {}
+              componentDidUpdate() {}
+              getSnapshotBeforeUpdate() {}
+              render() {
+                return null;
+              }
+            }
+
+            expect(console.error.mock.calls).toHaveLength(0);
+            polyfill(ComponentWithUnsafeWillUpdate);
+            expect(console.error.mock.calls).toHaveLength(1);
+            expect(console.error.mock.calls[0][0]).toEqual(
+              'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
+                'ComponentWithUnsafeWillUpdate uses getSnapshotBeforeUpdate() but also contains the following legacy lifecycles:\n' +
+                '  UNSAFE_componentWillUpdate\n\n' +
+                'The above lifecycles should be removed. Learn more about this warning here:\n' +
+                'https://fb.me/react-async-component-lifecycle-hooks'
+            );
+
+            console.error.mockClear();
+          });
+        }
       });
     });
   });


### PR DESCRIPTION
**This is a proposed 2.0.1 release. It adds additional, explicit warnings about unsupported combinations of old and new API lifecycles (e.g. `getSnapshotBeforeUpdate` and `componentWillMount`).**

A couple of things worth noting about this PR:
* With some lifecycle combinations (e.g. `getSnapshotBeforeUpdate` and `componentWillUpdate`) this change log to `console.error` in addition to throwing an Error.
* With React 16.3, this change will log a "duplicate" warning (since React would itself warn about this combination of lifecycles).

I think the above are acceptable, but I wanted to call them out specifically.

Relates to PR #14 