### PR TITLE
fix state not correct sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,9 @@ function componentWillMount() {
 
 function componentWillReceiveProps(nextProps) {
   // Call this.constructor.gDSFP to support sub-classes.
-  var state = this.constructor.getDerivedStateFromProps(nextProps, this.state);
-  if (state !== null && state !== undefined) {
-    this.setState(state);
-  }
+  this.setState(function updater(prevState) {
+    return this.constructor.getDerivedStateFromProps(nextProps, prevState) || {};
+  });
 }
 
 function componentWillUpdate(nextProps, nextState) {


### PR DESCRIPTION
Current `getDerivedStateFromProps` get `state` ood when `setState` is called which is not same behavior as `React 16.3`

```javascript
var state = this.constructor.getDerivedStateFromProps(nextProps, this.state);
```

Sample: https://codesandbox.io/s/nw3k9kqk00

------------

PS: But in old version of react, this change will cause re-render when user return null.