### PR TITLE
[index.js] Preact-friendly class component check

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ componentWillUpdate.__suppressDeprecationWarning = true;
 export function polyfill(Component) {
   var prototype = Component.prototype;
 
-  if (!prototype || !prototype.isReactComponent) {
+  if (!prototype || !prototype.render === 'function') {
     throw new Error('Can only polyfill class components');
   }
 


### PR DESCRIPTION
Taking the same approach as acdlite/recompose@1c9cf7b, this PR augments the class checking logic to support Preact.

In my particular use case, I am using [react-final-form-arrays](https://github.com/final-form/react-final-form-arrays) (which depends on this project, though it is [inlined ](https://unpkg.com/react-final-form-arrays@1.0.6/dist/react-final-form-arrays.es.js) in the distribution) (see line 59).

When using Preact, I get this exception:

```
[start:server] webpack-internal:///./node_modules/react-final-form-arrays/dist/react-final-form-arrays.es.js:68
[start:server]     throw new Error('Can only polyfill class components');
[start:server]     ^
[start:server] 
[start:server] Error: Can only polyfill class components
[start:server]     at polyfill (webpack-internal:///./node_modules/react-final-form-arrays/dist/react-final-form-arrays.es.js:68:11)
[start:server]     at eval (webpack-internal:///./node_modules/react-final-form-arrays/dist/react-final-form-arrays.es.js:512:1)
```

This PR fixes that thrown exception.