### PR TITLE
Revert "“vulnerabilities-removed”"

### DIFF
--- a/react/16.0/package.json
+++ b/react/16.0/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {
     "create-react-class": "^15.6.2",
     "react": "16.0",
-    "react-dom": ">=16.0.1",
+    "react-dom": "16.0",
     "react-test-renderer": "16.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,7 +2105,7 @@ node-pre-gyp@^0.6.39:
     request "2.81.0"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tar "^4.4.2"
+    tar "^2.2.1"
     tar-pack "^3.4.0"
 
 nopt@^4.0.1:
@@ -2906,12 +2906,12 @@ tar-pack@^3.4.0:
     once "^1.3.3"
     readable-stream "^2.1.4"
     rimraf "^2.5.1"
-    tar "^4.4.2"
+    tar "^2.2.1"
     uid-number "^0.0.6"
 
-tar@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.2.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
+tar@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
   dependencies:
     block-stream "*"
     fstream "^1.0.2"


### PR DESCRIPTION
Reverts reactjs/react-lifecycles-compat#34

The way this change was done doesn't make sense to me. Edits to `package.json` don't match the `yarn.lock` changes.

The premise also doesn't make sense because those are development deps.